### PR TITLE
Fix error handling in interactive mode

### DIFF
--- a/.tools/runtests
+++ b/.tools/runtests
@@ -5,5 +5,10 @@ for file in test/*.pow; do
   echo "-> $file"
   ./powscript $file
 done
+echo "Interactive mode tests:"
+for file in test/interactive/*.pow; do 
+  echo "-> $file"
+  ./powscript --interactive < $file
+done
 echo 'OK'
 exit 0

--- a/powscript
+++ b/powscript
@@ -526,10 +526,9 @@ lint_pipe(){
 }
 
 console(){
-  [[ ! $1 == "1" ]] && echo "hit ctrl-c to exit powscript, type 'edit' to launch editor, and 'help' for help"
-  trap 'console 1' 0 1 2 3 13 15 # EXIT HUP INT QUIT PIPE TERM SIGTERM SIGHUP
+  echo "hit ctrl-c to exit powscript, type 'edit' to launch editor, and 'help' for help"
   while IFS="" read -r -e -d $'\n' -p "> " line; do
-    "$1" "$line"
+    "$1" "$line" || [[ $? =~ (0|1|2|3|13|15) ]]
     history -s "$line"
   done
 }

--- a/src/powscript.bash
+++ b/src/powscript.bash
@@ -231,10 +231,9 @@ lint_pipe(){
 }
 
 console(){
-  [[ ! $1 == "1" ]] && echo "hit ctrl-c to exit powscript, type 'edit' to launch editor, and 'help' for help"
-  trap 'console 1' 0 1 2 3 13 15 # EXIT HUP INT QUIT PIPE TERM SIGTERM SIGHUP
+  echo "hit ctrl-c to exit powscript, type 'edit' to launch editor, and 'help' for help"
   while IFS="" read -r -e -d $'\n' -p "> " line; do
-    "$1" "$line"
+    "$1" "$line" || [[ $? =~ (0|1|2|3|13|15) ]]
     history -s "$line"
   done
 }

--- a/test/interactive/error-handling.pow
+++ b/test/interactive/error-handling.pow
@@ -1,0 +1,2 @@
+([
+echo 'I survived!'


### PR DESCRIPTION
Also introduce testing for interactive mode.
#### about this:

The `trap 'console 1'` trick was not working since 
1. `$1` would be `1` so it would call `1 "$line"`.
2. It would carry the `evalstr` var and throw the same error again.

It should have probably been something like:

``` bash
trap "evalstr='' console '$1' 1" ...
```

And then the first comparison would use `"$2"`. But even then, a command called by trap cannot itself trap anything, so the repl would catch the first error but then exit on the second. Thus, I removed the trap and used a `command || catch $?` pattern.
