### PR TITLE
Fix associative array tests on code-1.pow

### DIFF
--- a/test/code-1.pow
+++ b/test/code-1.pow
@@ -78,12 +78,12 @@ myfunc()
 simple_arrays
 associative_arrays
 
-foo={}
-bar={}
-foo["one"]="foo"
-bar["foo"]="123"
-map foo values | pipemap pick bar
-echo last="$(last foo)"
+afoo={}
+abar={}
+afoo["one"]="foo"
+abar["foo"]="123"
+map afoo values | pipemap pick abar
+echo last="$(last afoo)"
 
 math '9 / 2'
 math '9 / 2' 4


### PR DESCRIPTION
There were some naming conflicts.

Alright, that's it for now... All this was so that I could get all tests passing for my patch of more readable and strict tests, which you can preview in [this branch](https://github.com/fcard/powscript/tree/file-exit-on-error).

I also have a [newline escaping support patch](https://github.com/fcard/powscript/tree/newline-escaping) that is depending on #9.

Bye-bye for now!
