### PR TITLE
Remove \[,\],\{,\} and \! escapes

### DIFF
--- a/.tools/local-ci
+++ b/.tools/local-ci
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+if [[ -x $(command -v docker) ]]; then
+  docker build -t travis-powscript-test .
+  if [[ $1 =~ ("-i"|"--interactive") ]]; then
+    docker run -it travis-powscript-test /bin/bash
+  else
+    docker run travis-powscript-test
+  fi
+else
+  echo -e "please install docker.\n"
+fi
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM quay.io/travisci/travis-ruby:latest
+
+WORKDIR /home/travis/
+RUN mkdir powscript
+COPY . ./powscript
+USER travis
+WORKDIR /home/travis/powscript
+RUN {\
+ {\
+ linenum=0;\
+ while IFS="" read line; do\
+ linenum=$(($linenum+1));\
+ echo "$linenum|  $line";\
+ done;\
+ } < "./powscript";\
+}
+CMD {\
+ ./.tools/runtests;\
+}

--- a/lang/bash/.transpile
+++ b/lang/bash/.transpile
@@ -41,8 +41,14 @@ stack_update(){
   if ((indent_current < indent_last)); then stack_pop "$1"; fi
 }
 
+get_array_code(){
+  printf '"'
+  printf "\${$1[$2]}"
+  printf '"'
+}
+
 transpile_all(){
-  cat - | while IFS="" read -r line; do
+  while IFS="" read -r line; do
     i=$(getindent "$line")
     [[ "$line" =~ ^(#) ]] && local _comment="#"
     [[ "$line" =~ "={}" ]] && echo "$_comment$(makeindent $i)declare -A ${line/=\{\}/}" && continue
@@ -62,14 +68,14 @@ transpile_for(){
   if [[ "$code" =~ [a-zA-Z_0-9],[a-zA-Z_0-9] ]]; then
     local key="$(echo "$code" | awk '{ print $2 }' | awk -F',' '{ print $1 }')"
     local value="$(echo "$code" | awk '{ print $2 }' | awk -F',' '{ print $2 }')"
-    code="$code\n$indent$value=\"\${$arr[\$$key]}\""
+    code="$code\n$indent$value=$(get_array_code $arr "\$$key")"
     code="${code/,$value/}"
     code="${code/ of / in }"
-    code="${code/ $arr/ \"\${!$arr\[@\]\}\"}";
-  else
+    code="${code/ $arr/ $(get_array_code "!$arr" @)}";
+  elif [[ ! "$arr" == "\$@" ]]; then
     # iterate over indexed array
     local key="$(echo "$code" | awk '{ print $2 }')"
-    [[ ! "$arr" == "\$@" ]] && code="${code/ $arr/ \"\${$arr\[@\]\}\"}"
+    code="${code/ $arr/ $(get_array_code $arr @)}"
   fi
   echo -e "$code" | transpile_all
 }
@@ -90,7 +96,7 @@ transpile_if(){
 
 transpile_condition(){
   form=$1
-  code="${2/$form not/$form \!}"
+  code="${2/$form not/$form !}"
   firstvar="${code/\! /}"
   firstvar="$(echo "$firstvar" | awk '{ print $2 }')"
   code="${code// and / && }"
@@ -147,7 +153,7 @@ transpile_array_push(){
 }
 
 transpile_array_get(){
-  code="${1/\$/\"\$\{}"
+  code="${1/\$/\"\${}"
   echo "$code}\""
 }
 

--- a/lang/bash/mappipe
+++ b/lang/bash/mappipe
@@ -1,4 +1,4 @@
 mappipe(){
   func="$1"; shift
-  cat - | while read -r line; do $func "$@" "$line"; done
+  ( while read -r line; do $func "$@" "$line"; done )
 }

--- a/powscript
+++ b/powscript
@@ -87,8 +87,14 @@ stack_update(){
   if ((indent_current < indent_last)); then stack_pop "$1"; fi
 }
 
+get_array_code(){
+  printf '"'
+  printf "\${$1[$2]}"
+  printf '"'
+}
+
 transpile_all(){
-  cat - | while IFS="" read -r line; do
+  while IFS="" read -r line; do
     i=$(getindent "$line")
     [[ "$line" =~ ^(#) ]] && local _comment="#"
     [[ "$line" =~ "={}" ]] && echo "$_comment$(makeindent $i)declare -A ${line/=\{\}/}" && continue
@@ -108,14 +114,14 @@ transpile_for(){
   if [[ "$code" =~ [a-zA-Z_0-9],[a-zA-Z_0-9] ]]; then
     local key="$(echo "$code" | awk '{ print $2 }' | awk -F',' '{ print $1 }')"
     local value="$(echo "$code" | awk '{ print $2 }' | awk -F',' '{ print $2 }')"
-    code="$code\n$indent$value=\"\${$arr[\$$key]}\""
+    code="$code\n$indent$value=$(get_array_code $arr "\$$key")"
     code="${code/,$value/}"
     code="${code/ of / in }"
-    code="${code/ $arr/ \"\${!$arr\[@\]\}\"}";
-  else
+    code="${code/ $arr/ $(get_array_code "!$arr" @)}";
+  elif [[ ! "$arr" == "\$@" ]]; then
     # iterate over indexed array
     local key="$(echo "$code" | awk '{ print $2 }')"
-    [[ ! "$arr" == "\$@" ]] && code="${code/ $arr/ \"\${$arr\[@\]\}\"}"
+    code="${code/ $arr/ $(get_array_code $arr @)}"
   fi
   echo -e "$code" | transpile_all
 }
@@ -136,7 +142,7 @@ transpile_if(){
 
 transpile_condition(){
   form=$1
-  code="${2/$form not/$form \!}"
+  code="${2/$form not/$form !}"
   firstvar="${code/\! /}"
   firstvar="$(echo "$firstvar" | awk '{ print $2 }')"
   code="${code// and / && }"
@@ -193,7 +199,7 @@ transpile_array_push(){
 }
 
 transpile_array_get(){
-  code="${1/\$/\"\$\{}"
+  code="${1/\$/\"\${}"
   echo "$code}\""
 }
 
@@ -283,7 +289,7 @@ map(){
 }
 mappipe(){
   func="$1"; shift
-  cat - | while read -r line; do $func "$@" "$line"; done
+  ( while read -r line; do $func "$@" "$line"; done )
 }
 math(){
   if [[ -n "$2" ]]; then
@@ -471,6 +477,7 @@ compile(){
     [[ ! $PIPE == 2 ]] && for i in ${!footer[@]}; do echo "${footer[$i]}"; done 
   } | transpile_sh
   rm $tmpfile
+  rm $tmpfile.code
 }
 
 

--- a/src/powscript.bash
+++ b/src/powscript.bash
@@ -146,6 +146,7 @@ compile(){
     [[ ! $PIPE == 2 ]] && for i in ${!footer[@]}; do echo "${footer[$i]}"; done 
   } | transpile_sh
   rm $tmpfile
+  rm $tmpfile.code
 }
 
 


### PR DESCRIPTION
This was causing travis to fail. I also added a Dockerfile and a `.tools/local-ci` to test travis locally.
Some `cat -`s seemed to be segfaulting directly into travis' nuts so I took them out.
Is there any reason for them to be there?

The current test script wasn't failing on these, but you can see the output ending prematurely while with this it finishes at least the first test (the `code-1.pow` one still fails without #10 and #12). On my "strict tests" branch I got these:
- Build failling with the escapes: https://travis-ci.org/fcard/powscript/builds/151410389
- Build failing without a `cat -` removal (segfault): https://travis-ci.org/fcard/powscript/jobs/151717819
- Successful build with both: https://travis-ci.org/fcard/powscript/builds/151719855

I was gonna calm down with the million PRs but this one is a important part of the previous set I feel.
Now to sleep...

<s>P.S. WIP since this removes escapes that it shouldn't still.</s>
