### PR TITLE
Only rm temp file if it exists

### DIFF
--- a/powscript
+++ b/powscript
@@ -767,5 +767,7 @@ testdir(){
 
 ${startfunction} "$@" #"${0//.*\./}"
 
-rm "$tmpfile".* &>/dev/null
+for file in "$tmpfile"*; do
+  [[ -f $file ]] && rm "$file"
+done
 exit 0

--- a/src/powscript.bash
+++ b/src/powscript.bash
@@ -341,5 +341,7 @@ testdir(){
 
 ${startfunction} "$@" #"${0//.*\./}"
 
-rm "$tmpfile".* &>/dev/null
+for file in "$tmpfile"*; do
+  [[ -f $file ]] && rm "$file"
+done
 exit 0


### PR DESCRIPTION
Hello again!
I noticed the tests were failling, so I investigated a bit and noticed that this line:

```
rm "$tmpfile".* &>/dev/null
```

Was failing on interactive mode because no `"$tmpfile".*` file existed. (and thus was exiting with an error before `exit 0` could be reached)

---

I have a test next month I need to study for, so I don't have much time to look into this, do tell if there is a better solution ;P (once that is over I also have a few more PRs I want to make! Mostly complete multiline support in interactive mode and fixing this: `echo "$x $y"` compiles to `echo "$x "$y""`. Oops! It's a more complicated fix than it looks like...)
