### PR TITLE
Switched one line of printf to echo for %

### DIFF
--- a/powscript
+++ b/powscript
@@ -203,7 +203,7 @@ transpile_interpolate() {
       esac
     fi
     i=$(($i+1))
-    printf "$char"
+    echo -ne "$char"
   done
   $interpol && printf '"'
   echo $i > $_last_interpol_size


### PR DESCRIPTION
I was trying to use the `parted` command in powscript, in particular I require usage of the percent symbol `%`, which messed with `transpile_interpolate` function, giving errors of the following form during compilation

```
/home/darren/.bin/powscript: line 206: printf: `%': missing format character
/home/darren/.bin/powscript: line 206: printf: `%': missing format character
/home/darren/.bin/powscript: line 206: printf: `%': missing format character
/home/darren/.bin/powscript: line 206: printf: `%': missing format character
```

This PR is the simplest solution to deal with that, as I am not familiar with the escaping rules and escaping mechanism in `transpile_interpolate` function.