### PR TITLE
Rest arguments

### DIFF
--- a/.tools/runtests
+++ b/.tools/runtests
@@ -80,6 +80,9 @@ testdirectory "test/test-files" './powscript --no-std -c ${file} >/dev/null' '.*
 header "String tests:"
 testdirectory "test/strings" './powscript --no-std ${file}' 'file' '.*\.pow'
 
+header "Function tests:"
+testdirectory "test/functions" './powscript --no-std ${file}' 'file' '.*\.pow'
+
 header "Collections tests:"
 testdirectory "test/collections" './powscript --no-std ${file}' 'file' '.*\.pow'
 

--- a/powscript
+++ b/powscript
@@ -4278,7 +4278,9 @@ ast:lower-scanned() {
 __shadowing_ast:extract-function-arguments() {
   local args_expr="$1" out="$2"
   local positionals="" keywords=""
-  local arg args arg_head arg_value kw=false
+  local arg args arg_head arg_value
+  local kw=false has_rest_pos=false has_rest_kw=false
+  local rest_keyword rest_positional
   declare -i positional_count keyword_count
 
   positional_count=0
@@ -4290,16 +4292,42 @@ __shadowing_ast:extract-function-arguments() {
     ast:from $arg head arg_head
     case "$arg_head" in
       name)
-        if $kw; then
+        if { $has_rest_pos && ! $kw; } || $has_rest_kw; then
+          ast:error "'rest' argument must be the last of it's kind in the list ($arg_value)"
+
+        elif $kw; then
           keyword_count+=1
           ast:from $arg value arg_value
           ast:make arg name $arg_value
           keywords+=" $arg"
+
         else
           positional_count+=1
           positionals+=" $arg"
         fi
         ;;
+
+      cat)
+        local first second more
+        ast:children $arg first second more
+
+        if ast:is $first name '@' && ast:is $second name && [ -z "$more" ]; then
+          ast:from $second value arg_value
+
+          if { $has_rest_pos && ! $kw; } || $has_rest_kw; then
+            ast:error "'rest' argument must be the last of it's kind in the list ($arg_value)"
+          elif $kw; then
+            has_rest_kw=true
+            rest_keyword="$arg_value"
+          else
+            has_rest_pos=true
+            rest_positional="$arg_value"
+          fi
+        else
+          ast:error "Invalid name used for function argument (ast:print $arg)"
+        fi
+        ;;
+
       flag-double-dash-only)
         if $kw; then
           ast:error 'can only have one '--' in argument lists'
@@ -4313,15 +4341,35 @@ __shadowing_ast:extract-function-arguments() {
     esac
   done
 
-  case "$positional_count:$keyword_count" in
-    0:0)
-      ast:make "$out" nothing
+  case "$positional_count:$kw" in
+    0:false)
+      if $has_rest_pos; then
+        ast:make-from-string "$out" "
+        block
+        - declare array
+        -- name $rest_positional
+        - assign
+        -- name $rest_positional
+        -- list
+        --- simple-substitution @
+        "
+      else
+        ast:make "$out" nothing
+      fi
       ;;
-    *:0)
+    *:false)
       local locals test isset assign subst
       positional_count=1
       ast:make locals local '' $positionals
       ast:make "$out" block '' $locals
+      if $has_rest_pos; then
+        ast:make-from-string test "
+          declare array
+          - name $rest_positional
+        "
+        ast:push-child "${!out}" $test
+      fi
+
       for arg in $positionals; do
         ast:make-from-string test "
           condition and
@@ -4335,9 +4383,23 @@ __shadowing_ast:extract-function-arguments() {
         ast:push-child "${!out}" $test
         positional_count+=1
       done
+      if $has_rest_pos; then
+        ast:make-from-string test "
+          condition and
+          - condition >=
+          -- name \$#
+          -- name $positional_count
+          - assign
+          -- name $rest_positional
+          -- list
+          --- string-slice-from @
+          ---- name $positional_count
+        "
+        ast:push-child "${!out}" $test
+      fi
       ;;
-    *:*)
-      local argvar keyvar posvar locals arg_set arg_test key_assign
+    *:true)
+      local argvar keyvar posvar locals restdecs arg_set arg_test key_assign
       local key keyname keylocals="" keylocal
 
       ast:gensym argvar keyword_arg
@@ -4352,11 +4414,24 @@ __shadowing_ast:extract-function-arguments() {
 
       ast:make locals local '' $argvar $keyvar $posvar $positionals $keylocals
 
-      ast:make-argument-test  "$argvar" "$keyvar" "$posvar" "$positionals" arg_test
-      ast:make-keyword-assign "$argvar" "$keyvar" "$posvar" "$keywords"    key_assign
+      ast:make-argument-test  "$argvar" "$keyvar" "$posvar" "$positionals" "$rest_positional" arg_test
+      ast:make-keyword-assign "$argvar" "$keyvar" "$posvar" "$keywords"    "$rest_keyword"    key_assign
       ast:make-argument-set   "$argvar" "$keyvar" "$posvar" "$arg_test" "$key_assign" arg_set
 
-      ast:make "$out" block '' $locals $arg_set
+      if $has_rest_pos || $has_rest_kw; then
+        ast:make-from-string restdecs "
+          block
+          ${rest_positional:+"
+            - declare array
+            -- name $rest_positional
+          "}
+          ${rest_keyword:+"
+            - declare map
+            -- name $rest_keyword
+          "}
+        "
+      fi
+      ast:make "$out" block '' $locals $restdecs $arg_set
       ;;
   esac
 }
@@ -4420,7 +4495,7 @@ ast:make-argument-set() {
 
 
 __shadowing_ast:make-argument-test() {
-  local argvar="$1" keyvar="$2" posvar="$3" positionals="$4" out="$5"
+  local argvar="$1" keyvar="$2" posvar="$3" positionals="$4" rpos="$5" out="$6"
   local arg argcase cases=""
   local argvar_name posvar_name emptycases
   declare -i poscount=1
@@ -4447,7 +4522,27 @@ __shadowing_ast:make-argument-test() {
     poscount+=1
   done
 
-  [ -z "$cases" ] && emptycases="---- name true"
+  if [ -n "$rpos" ]; then
+    ast:make-from-string argcase "
+      case
+      - pattern *
+      - block
+      -- indexing-assign
+      --- name $rpos
+      --- array-length $rpos
+      --- simple-substitution $argvar_name
+      --+ $posvar
+      --- math-expr
+      ---- math +
+      ----+ $posvar
+      ----- name 1
+    "
+    cases+=" $argcase"
+  fi
+
+  if [ -z "$cases" ]; then
+    emptycases="---- name true"
+  fi
 
   ast:make-from-string "$out" "
     switch
@@ -4475,16 +4570,16 @@ __shadowing_ast:make-argument-test() {
 ast:make-argument-test() {
   if [ -z ${__noshadow_50_+x} ]; then
     local __noshadow_50_
-    local __noshadow_50_5
+    local __noshadow_50_6
   fi
-  __shadowing_ast:make-argument-test "$1" "$2" "$3" "$4"  __noshadow_50_5
-  setvar "$5" "$__noshadow_50_5"
+  __shadowing_ast:make-argument-test "$1" "$2" "$3" "$4" "$5"  __noshadow_50_6
+  setvar "$6" "$__noshadow_50_6"
 }
 
 
 
 __shadowing_ast:make-keyword-assign() {
-  local argvar="$1" keyvar="$2" posvar="$3" keywords="$4" out="$5"
+  local argvar="$1" keyvar="$2" posvar="$3" keywords="$4" rkey="$5" out="$6"
   local cases="" keycase key keyname keyshort
   local keyvar_name argvar_name
 
@@ -4506,18 +4601,41 @@ __shadowing_ast:make-keyword-assign() {
     cases+=" $keycase"
   done
 
+  if [ -n "$rkey" ]; then
+    ast:make-from-string keycase "
+    case
+    - pattern *
+    - block
+    -- assign
+    --+ $keyvar
+    --- string-slice-from $keyvar_name
+    ---- name 1
+    -- indexing-assign
+    --- name $rkey
+    --- string-removal $keyvar_name
+    ---- pattern -
+    ---- name #
+    --- simple-substitution $argvar_name
+    "
+    cases+=" $keycase"
+  else
+    ast:make-from-string keycase "
+    case
+    - pattern *
+    - block
+    -- call
+    --- assign-sequence
+    --- name :
+    "
+    cases+=" $keycase"
+  fi
+
   ast:make-from-string "$out" "
     block
     - switch
     -- simple-substitution $keyvar_name
     -- block
     --+ $cases
-    --- case
-    ---- pattern *
-    ---- block
-    ----- call
-    ------ assign-sequence
-    ------ name :
     - assign
     -+ $keyvar
     -- string
@@ -4527,10 +4645,10 @@ __shadowing_ast:make-keyword-assign() {
 ast:make-keyword-assign() {
   if [ -z ${__noshadow_51_+x} ]; then
     local __noshadow_51_
-    local __noshadow_51_5
+    local __noshadow_51_6
   fi
-  __shadowing_ast:make-keyword-assign "$1" "$2" "$3" "$4"  __noshadow_51_5
-  setvar "$5" "$__noshadow_51_5"
+  __shadowing_ast:make-keyword-assign "$1" "$2" "$3" "$4" "$5"  __noshadow_51_6
+  setvar "$6" "$__noshadow_51_6"
 }
 
 
@@ -4571,7 +4689,7 @@ __shadowing_typing:declared-name() {
 
   ast:from $expr head expr_head
   case $expr_head in
-    name|flag-double-dash-only)
+    name|flag-double-dash-only|cat)
       ;;
     *assign)
       ast:children $expr expr

--- a/test/functions/definition.pow
+++ b/test/functions/definition.pow
@@ -1,7 +1,7 @@
 bbar()
   echo flop
 
-foo( a, b )
+foo(a b)
   echo a=$a b=$b
 
 foo one two

--- a/test/functions/rest.pow
+++ b/test/functions/rest.pow
@@ -1,0 +1,34 @@
+f(@all)
+  echo $all[*]
+
+assert $(f 1) is "1"
+assert $(f 1  2  3) is "1 2 3"
+
+g(a b @c)
+  echo $c[*] $a $b
+
+assert $(g 1 2) is " 1 2"
+assert $(g 1 2 3 4) is "3 4 1 2"
+
+k(-- @ks)
+  echo ${ks:keys} ${ks[@]}
+
+assert $(k 1 2) is ""
+assert $(k 1 2 --x a) is "x a"
+assert $(k 1 2 --y a) is "y a"
+assert $(k 1 2  -y a) is "y a"
+
+h(-- x y @ks)
+  echo $x $y ${ks:keys}
+
+assert $(h 1 2) is " "
+assert $(h 1 2 --x a) is "a "
+assert $(h 1 2 --y a) is " a"
+assert $(h --x a --y b --z c) is "a b z"
+
+a(@ps -- @ks)
+  echo $ps[@] $ks[@]
+
+assert $(a 1 --x 2) is "1 2"
+assert $(a 1 --x 3 2) is "1 2 3"
+


### PR DESCRIPTION
This PR introduces `rest` (or `vararg`) arguments that allows one to collect a variable number of arguments into an array:
```sh
f(a b @c)
  echo $c[@]

f 1 2 3 4 #> 3 4

k(-- x y @z)
  echo $z[@] ${z:keys}

k -x 1 -y 2 -a 3 -b 4 -c 5 #> 3 4 5 a b c
```