### PR TITLE
Fix pgrep and mktemp so they remain POSIX but actually work

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powscript",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "bash dialect transpiler in bash: painless shellscript / indentbased / coffeescript for shellscript / bash for hipsters",
   "main": "powscript",
   "directories": {

--- a/powscript
+++ b/powscript
@@ -6108,11 +6108,11 @@ backend:select() {
 
 # FILE: lang/backends.bash
 
-PowscriptTempDirectory="$(mktemp -d .powscript.XXXXXX )"
+PowscriptTempDirectory="$(mkdir "$(mktemp -u).powscript")"
 
 powscript:temp-name() {
   local suffix=".powscript$1"
-  setvar "$2" "$(mktemp -u -p "$PowscriptTempDirectory").$1"
+  setvar "$2" "$(mktemp -u -p "$PowscriptTempDirectory")$suffix"
 }
 
 powscript:make-temp() {
@@ -6129,7 +6129,7 @@ powscript:clean-up() {
   local exit_code=$?
   POWSCRIPT_CDEBUG_STOP=false
   [ -d "$PowscriptTempDirectory" ] && rm -r "$PowscriptTempDirectory"
-  [ -n "$PowscriptGuestProcess"  ] && pgrep "$PowscriptGuestProcess" >/dev/null && kill -QUIT "$PowscriptGuestProcess"
+  [ -n "$PowscriptGuestProcess"  ] && pgrep -P "$PowscriptGuestProcess" >/dev/null && kill -QUIT "$PowscriptGuestProcess"
   exit $exit_code
 }
 
@@ -6172,7 +6172,7 @@ powscript:help() {
   '
 }
 # FILE: compiler/helptext.bash
-POWSCRIPT_VERSION=1.1.14
+POWSCRIPT_VERSION=1.1.15
 
 version:number() {
   echo "$POWSCRIPT_VERSION"
@@ -6487,7 +6487,7 @@ interactive:start() {
     files:compile-file "$wfifo" <"$HOME/.powrc"
   fi
 
-  while pgrep $proc >/dev/null; do
+  while pgrep -P $proc >/dev/null; do
     result=
 
     if [ -n "${extra_line// /}" ]; then

--- a/src/compiler/interactive.bash
+++ b/src/compiler/interactive.bash
@@ -30,7 +30,7 @@ interactive:start() {
     files:compile-file "$wfifo" <"$HOME/.powrc"
   fi
 
-  while pgrep $proc >/dev/null; do
+  while pgrep -P $proc >/dev/null; do
     result=
 
     if [ -n "${extra_line// /}" ]; then

--- a/src/compiler/temp.bash
+++ b/src/compiler/temp.bash
@@ -1,9 +1,9 @@
 
-PowscriptTempDirectory="$(mktemp -d .powscript.XXXXXX )"
+PowscriptTempDirectory="$(mkdir "$(mktemp -u).powscript")"
 
 powscript:temp-name() {
   local suffix=".powscript$1"
-  setvar "$2" "$(mktemp -u -p "$PowscriptTempDirectory").$1"
+  setvar "$2" "$(mktemp -u -p "$PowscriptTempDirectory")$suffix"
 }
 
 powscript:make-temp() {
@@ -20,7 +20,7 @@ powscript:clean-up() {
   local exit_code=$?
   POWSCRIPT_CDEBUG_STOP=false
   [ -d "$PowscriptTempDirectory" ] && rm -r "$PowscriptTempDirectory"
-  [ -n "$PowscriptGuestProcess"  ] && pgrep "$PowscriptGuestProcess" >/dev/null && kill -QUIT "$PowscriptGuestProcess"
+  [ -n "$PowscriptGuestProcess"  ] && pgrep -P "$PowscriptGuestProcess" >/dev/null && kill -QUIT "$PowscriptGuestProcess"
   exit $exit_code
 }
 


### PR DESCRIPTION
`pgrep` needed the `-P` option to be equivalent to `ps -p`, and `mktemp` had some other oddities going on. I don't have the tools to test that these are POSIX compatible right now, so if you could check a look, @coderofsalvation, I'd be really grateful!