### PR TITLE
Add the shebang #! upon compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powscript",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "bash dialect transpiler in bash: painless shellscript / indentbased / coffeescript for shellscript / bash for hipsters",
   "main": "powscript",
   "directories": {

--- a/powscript
+++ b/powscript
@@ -5283,6 +5283,14 @@ backend:compile-children() {
 }
 
 # FILE: lang/common.bash
+FileStartBash="\
+#!/usr/bin/env bash
+"
+
+bash:file-start() {
+  echo "$FileStartBash"
+}
+# FILE: lang/bash/start.bash
 bash:interactive() {
   local wfifo="$1"
   local rfifo="$2"
@@ -5642,6 +5650,14 @@ bash:compile() {
 }
 
 # FILE: lang/bash/compile.bash
+FileStartSh="\
+#!/usr/bin/env sh
+"
+
+sh:file-start() {
+  echo "$FileStartSh"
+}
+# FILE: lang/sh/start.bash
 sh:interactive() {
   local wfifo="$1"
   local rfifo="$2"
@@ -6221,6 +6237,7 @@ backend:select() {
     backend:compile     () { ${1}:compile     \"\$@\"; }
     backend:interactive () { ${1}:interactive \"\$@\"; }
     backend:run         () { ${1}:run         \"\$@\"; }
+    backend:file-start  () { ${1}:file-start  \"\$@\"; }
   "
 }
 
@@ -6290,7 +6307,7 @@ powscript:help() {
   '
 }
 # FILE: compiler/helptext.bash
-POWSCRIPT_VERSION=1.1.16
+POWSCRIPT_VERSION=1.1.17
 
 version:number() {
   echo "$POWSCRIPT_VERSION"
@@ -6560,6 +6577,7 @@ files:compile-file() {
 }
 
 files:start-code() {
+  backend:file-start >>"$1"
   files:compile-file "$1" <<<"$PowscriptFileStart"$'\n\n'
 
   if ${PowscriptIncludeStd-true}; then

--- a/src/compiler/files.bash
+++ b/src/compiler/files.bash
@@ -35,6 +35,7 @@ files:compile-file() {
 }
 
 files:start-code() {
+  backend:file-start >>"$1"
   files:compile-file "$1" <<<"$PowscriptFileStart"$'\n\n'
 
   if ${PowscriptIncludeStd-true}; then

--- a/src/lang/backends.bash
+++ b/src/lang/backends.bash
@@ -9,6 +9,7 @@ backend:select() {
     backend:compile     () { ${1}:compile     \"\$@\"; }
     backend:interactive () { ${1}:interactive \"\$@\"; }
     backend:run         () { ${1}:run         \"\$@\"; }
+    backend:file-start  () { ${1}:file-start  \"\$@\"; }
   "
 }
 

--- a/src/lang/bash/compile.bash
+++ b/src/lang/bash/compile.bash
@@ -1,3 +1,4 @@
+powscript_source lang/bash/start.bash       #<<EXPAND>>
 powscript_source lang/bash/interactive.bash #<<EXPAND>>
 
 bash:run() {

--- a/src/lang/bash/start.bash
+++ b/src/lang/bash/start.bash
@@ -1,0 +1,7 @@
+FileStartBash="\
+#!/usr/bin/env bash
+"
+
+bash:file-start() {
+  echo "$FileStartBash"
+}

--- a/src/lang/sh/compile.bash
+++ b/src/lang/sh/compile.bash
@@ -1,3 +1,4 @@
+powscript_source lang/sh/start.bash       #<<EXPAND>>
 powscript_source lang/sh/interactive.bash #<<EXPAND>>
 
 sh:run() {

--- a/src/lang/sh/start.bash
+++ b/src/lang/sh/start.bash
@@ -1,0 +1,7 @@
+FileStartSh="\
+#!/usr/bin/env sh
+"
+
+sh:file-start() {
+  echo "$FileStartSh"
+}

--- a/test/etc/shebang.bash
+++ b/test/etc/shebang.bash
@@ -1,0 +1,12 @@
+file=$(mktemp -u).powscript
+./powscript -c <(echo "echo 'hello world (bash)'") -o $file.bash
+./powscript -c <(echo "echo 'hello world (sh)'") --to sh -o $file.sh
+
+chmod +x $file.bash
+chmod +x $file.sh
+
+$file.bash
+$file.sh
+
+rm $file.bash
+rm $file.sh


### PR DESCRIPTION
Something essential I ended up forgetting was having the compiler add the "shebang" line at the start of the script. This fixes that, adding the proper one according to the selected backend (`env bash` or `env sh`)

